### PR TITLE
Added the ability to have migrations in a directory with one sql file…

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,13 +7,13 @@ var libDir = path.join(__dirname, 'lib', 'db');
 var massiveMigrate = function(options, callback) {
 
     massive.connect({connectionString: options.connectionString, scripts: libDir}, function (err, db) {
-        if (err) callback(err, null);
+        if (err) return callback(err, null);
 
         ensureMigrationTableExists(db, function(err) {
-            if (err) callback(err, null);
+            if (err) return callback(err, null);
 
             massive.connect(db, function (err, db) {
-                if (err) callback(err, null);
+                if (err) return callback(err, null);
 
                 var migrationsOptions = options;
                 migrationsOptions.database = db;

--- a/lib/migrations.js
+++ b/lib/migrations.js
@@ -13,81 +13,118 @@ var migrations = function (options) {
 
 };
 
-migrations.prototype.hasUpMigration = function (name, callback) {
+migrations.prototype.hasUpMigrationBeenApplied = function (name, callback) {
     this.database.pgmigration.findOne({
         name: name,
         scriptname: name + '-up'
     }, function (err, result) {
         callback(err, !!result)
     });
-};
+}
+
+// Provides backwards compatibility
+migrations.prototype.hasUpMigration = function () {
+    this.hasUpMigrationBeenApplied.apply(this, Array.prototype.slice.call(arguments));
+}
 
 migrations.prototype.getAppliedMigrations = function (callback) {
     this.database.pgmigration.find({}, function (err, appliedMigrations) {
         callback(err, appliedMigrations);
-    })
-};
+    });
+}
 
 migrations.prototype.runUpMigration = function (options, callback) {
     var that = this;
-    this.hasUpMigration(options.name, function (err, result) {
+    this.hasUpMigrationBeenApplied(options.name, function (err, result) {
         if (!result) {
             var migrationOptions = options;
             options.connectionString = that.options.connectionString;
             options.directory = that.options.directory;
-            runUpMigration(migrationOptions, callback)
+            runUpMigration(migrationOptions, callback);
         } else {
-            callback('Migration has been applied already')
+            callback('Migration has been applied already');
         }
-    })
-};
+    });
+}
 
 
 function runUpMigration(options, callback) {
+    // If a callback is not provided declare an empty method to avoid checks
+    if (! callback) { callback = function() {} }
+
     var conn = options.connectionString;
     var script = options.name + '-up';
     var directory = options.directory;
     var name = options.name;
     var upDir = path.join(directory,name,'up');
-    copySqlFilesToTempDir(upDir, function (err, tempDir) {
-        massive.connect({connectionString: conn, scripts: tempDir}, function (err, database) {
-            var upscript = require(path.join(directory,name,script));
-            upscript.up(database, options, function (err) {
-                if (!err) {
-                    database.pgmigration.insert({
-                        name: name,
-                        scriptname: script
-                    }, function (err) {
-                        if (!err) {
+
+    fs.access(upDir, fs.F_OK, function(err) {
+        if (err) {
+            // Migration directory doesn't exist. Proceed as if this is a migration in a file that doesn't use directories
+            var sqlScriptFileName = path.join(directory, name) + '-up.sql';
+            fs.readFile(sqlScriptFileName, 'utf8', function (err, data) {
+                if (err) return callback(err);
+
+                massive.connect({connectionString: conn}, function (err, database) {
+                    if (err) return callback(err);
+
+                    database.run(data, function(err, result){
+                        if (err) return callback(err);
+
+                        persistExecutedMigration(database, name, script, function(err) {
                             temp.cleanup();
-                            if (callback) {
-                                callback()
-                            }
-                        } else {
-                            if (callback) {
-                                callback(err)
-                            }
-                        }
-                    })
-                }
-            })
-        });
+                            return callback(err);
+                        });
+                    });
+                });
+            });
+        } else {
+            // Found the directory proceed with running the up script
+            copySqlFilesToTempDir(upDir, function (err, tempDir) {
+                if (err) return callback(err);
+
+                massive.connect({connectionString: conn, scripts: tempDir}, function (err, database) {
+                    if (err) return callback(err);
+
+                    var upscript = require(path.join(directory,name,script));
+                    upscript.up(database, options, function (err) {
+                        if (err) return callback(err);
+
+                        persistExecutedMigration(database, name, script, function(err) {
+                            temp.cleanup();
+                            return callback(err);
+                        });
+                    });
+                });
+            });
+        }
     });
 }
 
-
+function persistExecutedMigration(database, name, script, callback) {
+    database.pgmigration.insert({
+        name: name,
+        scriptname: script
+    }, function (err) {
+        callback(err);
+    });
+}
 
 function copySqlFilesToTempDir(upDir, callback) {
     fs.readdir(upDir, function (err, result) {
+        if (err) return callback(err);
+
         temp.mkdir('massive-migrate', function (err, tempDir) {
+            if (err) return callback(err);
+
             async.each(result, function (sqlFile, callback) {
                 copyFile(path.join(upDir,sqlFile), path.join(tempDir,sqlFile), callback)
             }, function (err) {
-                if (!err) {
-                    callback(null, tempDir);
-                }
-            })
-        })
+                if (err) return callback(err);
+
+                callback(null, tempDir);
+            });
+        });
     });
 }
 

--- a/lib/migrations.js
+++ b/lib/migrations.js
@@ -61,20 +61,15 @@ function runUpMigration(options, callback) {
     fs.access(upDir, fs.F_OK, function(err) {
         if (err) {
             // Migration directory doesn't exist. Proceed as if this is a migration in a file that doesn't use directories
-            var sqlScriptFileName = path.join(directory, name) + '-up.sql';
-            fs.readFile(sqlScriptFileName, 'utf8', function (err, data) {
+            massive.connect({connectionString: conn, scripts: directory}, function (err, database) {
                 if (err) return callback(err);
 
-                massive.connect({connectionString: conn}, function (err, database) {
+                database[script](function(err, result) {
                     if (err) return callback(err);
 
-                    database.run(data, function(err, result){
-                        if (err) return callback(err);
-
-                        persistExecutedMigration(database, name, script, function(err) {
-                            temp.cleanup();
-                            return callback(err);
-                        });
+                    persistExecutedMigration(database, name, script, function(err) {
+                        temp.cleanup();
+                        return callback(err);
                     });
                 });
             });

--- a/test/migrations/onemigrationperfile/0.1.0-up.sql
+++ b/test/migrations/onemigrationperfile/0.1.0-up.sql
@@ -1,0 +1,17 @@
+BEGIN;
+-- DROP TABLE IF EXISTS customer;
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE TABLE IF NOT EXISTS Customer (
+  ID UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  companyname1 VARCHAR(40),
+  companyname2 VARCHAR(40),
+  addressline1 VARCHAR(40),
+  addressline2 VARCHAR(40),
+  zipcode VARCHAR(10),
+  city VARCHAR(40),
+  existingcustomernumber VARCHAR(40),
+  salestaxidentificationnumber VARCHAR(14),
+  customersuppliernumber VARCHAR(40),
+  createdat DATE DEFAULT now()
+);
+END;

--- a/test/migrations/onemigrationperfile/0.2.0-up.sql
+++ b/test/migrations/onemigrationperfile/0.2.0-up.sql
@@ -1,0 +1,11 @@
+BEGIN;
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE TABLE IF NOT EXISTS salutation (
+  ID UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  salutation VARCHAR(40),
+  male BOOL,
+  female BOOL,
+  genderless BOOL,
+  createdat DATE DEFAULT now()
+);
+END;

--- a/test/test.js
+++ b/test/test.js
@@ -19,7 +19,6 @@ describe('when migrating from an empty database to first version', function () {
         var options = {connectionString: conn, directory: path.join(__dirname, 'migrations', 'fromscratch')};
         massiveMigrate(options, function (err, migrations) {
             should.not.exist(err);
-            migrations.runUpMigration({name: '0.1.0'});
             migrations.runUpMigration({name: '0.1.0'}, function (err) {
                 should.not.exist(err);
                 massive.connect({connectionString: conn}, function (dbErr, db) {

--- a/test/test.js
+++ b/test/test.js
@@ -292,14 +292,10 @@ describe('when there is 1 sql file per migration', function () {
 function removeTables(callback) {
     var massive = require('massive');
     massive.connect({connectionString: conn, scripts: __dirname + '/db'}, function (err, db) {
-        if (!err) {
-            db.droptables(function (err) {
-                if (!err) {
-                    callback()
-                } else {
-                    callback(err)
-                }
-            })
-        }
-    })
+        if (err) return callback(err);
+
+        db.droptables(function (err) {
+            callback(err);
+        });
+    });
 }


### PR DESCRIPTION
… per migration (without sub directories or up scripts)

I changed more than required for the feature and added additional error checking.  If you would rather have the code exactly as it was with just the feature added let me know and I'll start from master and just add the necessary changes.

With the changes the migrations folder can be structured like:

```
|- migrations
  |- 0.1.0-up.sql
  |- 0.2.0-up.sql
  |- anything-up.sql
```

And run a migration like:

```
migrations.runUpMigration({name: '0.1.0'}, function (err) {
});
```

My driver script is going to iterate over each file checking if the migration has already ran and if not call runUpMigration.

Since it checks the folder / file per call to runUpMigrations it's possible to have a directory structure like:

```
|- migrations
  |- 0.1.0-up.sql
  |- 0.2.0
  |   |- up
  |   |  |- createcustomertable.sql
  |   |  |-  createsalutationtable.sql
  |   |- 0.2.0-up.js
  |- 0.3.0-up.sql
```
